### PR TITLE
kmer length could be shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ options:
 ```shel
   -f, --fasta            FASTA input file name (string)
   -o, --outdir           Directory for output. Default is unique_kmers in the current directory. (string [=unique_kmers])
-  -k, --kmer             The length k of k-mer (10~32), default 25 (int [=25])
+  -k, --kmer             The length k of k-mer (3~32), default 25 (int [=25])
   -s, --spacing          If a key with POS is recorded, then skip [POS+1...POS+spacing] to avoid too compact result (0~100). default 0 means no skipping. (int [=0])
   -g, --genome_limit     Process up to genome_limit genomes in the FASTA input file. Default 0 means no limit. This option is for DEBUG. (int [=0])
   -r, --ref              Reference genome FASTA file name. Specify this only when you want to filter out the unique k-mer that can be mapped to reference genome. (string [=])

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -42,8 +42,8 @@ bool Options::validate() {
             error_exit("Not a directory: " + outdir);
     }
 
-    if(kmerKeyLen < 10 || kmerKeyLen > 32)
-        error_exit("KMER length (-k) should be between 10 ~ 32, suggest 25");
+    if(kmerKeyLen < 3 || kmerKeyLen > 32)
+        error_exit("KMER length (-k) should be between 3 ~ 32, suggest 25");
 
     if(edThreshold < 0 || edThreshold > 16)
         error_exit("Edit distance threshold (-e) should be between 0 ~ 16, suggest 3");


### PR DESCRIPTION
Frequently , lab pals want to find unique oligonucleotides whose length are 5 bps or so.
And it seems no harm to lower the limitation.